### PR TITLE
Webpack build

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -19,6 +19,10 @@ var publicUrl = '';
 // Get environment variables to inject into our app.
 var env = getClientEnvironment(publicUrl);
 
+var provided = {
+  'Web3': 'web3'
+}
+
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -154,9 +158,6 @@ module.exports = {
         query: {
           name: 'static/media/[name].[hash:8].[ext]'
         }
-      },
-      {
-        test: /\.sol/, loader: 'truffle-solidity'
       }
     ]
   },
@@ -189,6 +190,8 @@ module.exports = {
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.
     new webpack.DefinePlugin(env),
+    // use web3 as provided
+    new webpack.ProvidePlugin(provided),
     // This is necessary to emit hot updates (currently CSS only):
     new webpack.HotModuleReplacementPlugin(),
     // Watcher doesn't work well if you mistype casing in a path so we use

--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.2;
 
-import "ConvertLib.sol";
+import "./ConvertLib.sol";
 
 // This is just a simple example of a coin-like contract.
 // It is not standards compatible and cannot be expected to talk to other

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,3 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(Migrations);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,6 +1,10 @@
+var ConvertLib = artifacts.require("./ConvertLib.sol");
+var MetaCoin = artifacts.require("./MetaCoin.sol");
+var SimpleWallet = artifacts.require("./SimpleWallet.sol");
+
 module.exports = function(deployer) {
   deployer.deploy(ConvertLib);
-  deployer.autolink();
+  deployer.link(ConvertLib, MetaCoin);
   deployer.deploy(MetaCoin);
   deployer.deploy(SimpleWallet);
 };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     "babel-eslint": "7.1.1",
     "babel-jest": "17.0.2",
     "babel-loader": "6.2.7",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-es2016": "^6.22.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-react-app": "^2.0.1",
+    "babel-register": "^6.22.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",
@@ -43,8 +46,9 @@
     "reflux": "^5.0.4",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
-    "truffle-solidity-loader": "0.0.8",
+    "truffle-contract": "^1.1.8",
     "url-loader": "0.5.7",
+    "web3": "^0.18.2",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
@@ -52,13 +56,17 @@
   },
   "dependencies": {
     "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "uport-lib": "git://github.com/ConsenSys/uport-lib.git#develop"
+    "react-dom": "^15.4.2"
   },
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"
+  },
+  "standard": {
+    "globals": [
+      "web3"
+    ]
   },
   "jest": {
     "collectCoverageFrom": [
@@ -87,7 +95,8 @@
   "babel": {
     "presets": [
       "react",
-      "es2015"
+      "es2015",
+      "es2016"
     ]
   },
   "eslintConfig": {

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>React dApp</title>
   </head>
   <body>
     <div class="container">

--- a/src/components/Routes.jsx
+++ b/src/components/Routes.jsx
@@ -14,8 +14,8 @@ var Routes = React.createClass({
       <Router history={hashHistory}>
         <Route path="/" component={BasePage}>
           <IndexRoute component={HomePage} />
-          <Route path="/simplewallet" component={SimpleWalletView} />
-          <Route path="/metacoin" component={MetaCoinView} />
+          <Route path="/simplewallet" component={() => (<SimpleWalletView web3={this.props.web3} />)} />
+          <Route path="/metacoin" component={() => (<MetaCoinView web3={this.props.web3} />)} />
           <Route path="/uport" component={UPortView} />
           <Route path="temperature" component={Calculator} />
         </Route>

--- a/src/components/metacoin/MetaCoinView.jsx
+++ b/src/components/metacoin/MetaCoinView.jsx
@@ -9,13 +9,28 @@ import AccountSummary from '../accounts/AccountSummary.jsx';
 import AmountInput from '../inputs/AmountInput.jsx';
 import SendButton from '../buttons/SendButton.jsx';
 
-// import MetaCoin from '../../../build/contracts/MetaCoin.sol.js';
+import { default as contract } from 'truffle-contract'
+
+// Import our contract artifacts and turn them into usable abstractions.
+import metacoin_artifacts from '../../../build/contracts/MetaCoin.json'
+
 var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
-var metacoinContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"getBalanceInEth","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"receiver","type":"address"},{"name":"amount","type":"uint256"}],"name":"sendCoin","outputs":[{"name":"sufficient","type":"bool"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"getBalance","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"inputs":[],"payable":false,"type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Transfer","type":"event"}]);
+// MetaCoin is our usable abstraction, which we'll use through the code below.
+var MetaCoin = contract(metacoin_artifacts);
+// Bootstrap the MetaCoin abstraction for Use.
+MetaCoin.setProvider(web3.currentProvider);
 
-// access a contract already deployed to a specific address
-var metacoin = metacoinContract.at("0xb85c25f82987e295ed786b64a43bf48ccb33c2d7");
+// const provider = new Web3.providers.HttpProvider('http://localhost:8545');
+// MetaCoin.setProvider(provider);
+
+// import MetaCoin from '../../../build/contracts/MetaCoin.sol.js';
+// var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+//
+// var metacoinContract = web3.eth.contract([{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"getBalanceInEth","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"receiver","type":"address"},{"name":"amount","type":"uint256"}],"name":"sendCoin","outputs":[{"name":"sufficient","type":"bool"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"addr","type":"address"}],"name":"getBalance","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"inputs":[],"payable":false,"type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Transfer","type":"event"}]);
+//
+// // access a contract already deployed to a specific address
+// var metacoin = metacoinContract.at("0xd92099a362198f6ce5537cc5f57f0e9ca168cd6e");
 
 // Create a new contract
 // var metacoin = metacoinContract.new(
@@ -49,10 +64,26 @@ var MetaCoinView = React.createClass( {
     this.setState({toAddress: value});
   },
   handleSend: function() {
-    console.log('sending ' + this.state.amount + " to " + this.state.toAddress);
+    //console.log('sending ' + this.state.amount + " to " + this.state.toAddress);
 //    console.log(metacoin.getBalance(this.state.toAddress));
-    console.log('sending coin: ' + metacoin.sendCoin(this.state.toAddress, 100));
+    //console.log('sending coin: ' + metacoin.sendCoin(this.state.toAddress, this.state.amount));
+    // var metacoin = MetaCoin.deployed();
+    var amount = this.state.amount;
+    var toAddress = this.state.toAddress;
+    var fromAddress = '0xe6e8225f0c328a7e9b9a869bebb1262f25dc65cc';
 
+    var meta;
+    MetaCoin.deployed().then(function(instance) {
+      meta = instance;
+      // return meta.sendCoin(this.state.toAddress, this.state.amount, {from: account});
+      return meta.sendCoin(toAddress, amount, {from: fromAddress});
+    }).then(function() {
+      console.log('Transaction successful!');
+    }).catch(function(e) {
+      console.log(e);
+    });
+    // var resp = metacoin.sendCoin(this.state.toAddress, this.state.amount);
+    // console.log('resp: ' + resp);
   },
   render: function() {
     return (

--- a/src/components/reflux/AccountStore.jsx
+++ b/src/components/reflux/AccountStore.jsx
@@ -2,31 +2,42 @@ import Reflux from 'reflux';
 import Actions from './actions.jsx';
 import Web3 from 'web3';
 
-var web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+// import truffleConfig from '../../../truffle.js';
+
+// var web3Location = `http://${truffleConfig.rpc.host}:${truffleConfig.rpc.port}`
+var web3Location = 'http://localhost:8545';
+var web3Provided;
+// Supports Metamask and Mist, and other wallets that provide 'web3'.
+if (typeof web3 === 'undefined') {
+  // Use the Mist/wallet provider.
+  // eslint-disable-next-line
+  web3Provided = new Web3(web3.currentProvider);
+} else {
+  web3Provided = new Web3(new Web3.providers.HttpProvider(web3Location))
+}
 
 var AccountStore = Reflux.createStore({
   listenables: [Actions],
   getAccounts: function() {
-    let _accounts = [];
     //web3.eth.accounts.map(function(account) {
-    var addresses = web3.eth.accounts;
-    for (var i = 0; i < addresses.length; i++) {
-      _accounts.push({address: addresses[i],
-        balance: web3.fromWei(web3.eth.getBalance(addresses[i]), 'ether')
-      });
-    };
-    this.accounts = _accounts;
-    this.fireUpdate();
+    web3Provided.eth.getAccounts(function(error, addresses) {
+      let _accounts = [];
+      for (var i = 0; i < addresses.length; i++) {
+        _accounts.push({address: addresses[i], balance: web3Provided.fromWei(web3Provided.eth.getBalance(addresses[i]), 'ether') })
+      };
+      this.accounts = _accounts;
+      this.fireUpdate();
+    }.bind(this));
   },
   getAddressList: function() {
-    this.addressList = web3.eth.accounts;
+    this.addressList = web3Provided.eth.accounts;
     // this.addressList = _accounts.map(function(account) {
     //   return {address: account};
     // })
     this.trigger('change', this.addressList);
   },
   getBalance: function(_account) {
-    this.balance = web3.fromWei(web3.eth.getBalance(_account), 'ether');
+    this.balance = web3Provided.fromWei(web3Provided.eth.getBalance(_account), 'ether');
     this.trigger('change', this.balance);
   },
   fireUpdate: function() {

--- a/src/components/wallets/SimpleWalletView.jsx
+++ b/src/components/wallets/SimpleWalletView.jsx
@@ -9,14 +9,24 @@ import AddressDropdown from '../accounts/AddressDropdown';
 import AmountInput from '../inputs/AmountInput.jsx';
 import SendButton from '../buttons/SendButton.jsx';
 
-//import SimpleWallet from '../../../contracts/SimpleWallet.sol';
+import { default as contract } from 'truffle-contract'
+
+// Import our contract artifacts and turn them into usable abstractions.
+import simpleWallet_artifacts from '../../../build/contracts/SimpleWallet.json'
 
 var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
-var simplewalletContract = web3.eth.contract([{"constant":true,"inputs":[{"name":"_address","type":"address"}],"name":"isAllowedToSend","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"amount","type":"uint256"},{"name":"receiver","type":"address"}],"name":"sendFunds","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"constant":false,"inputs":[],"name":"killWallet","outputs":[],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"_address","type":"address"}],"name":"allowAddressToSendMoney","outputs":[],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"_address","type":"address"}],"name":"disallowAddressToSendMoney","outputs":[],"payable":false,"type":"function"},{"inputs":[],"payable":false,"type":"constructor"},{"payable":true,"type":"fallback"},{"anonymous":false,"inputs":[{"indexed":false,"name":"_sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"_sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"_beneficiary","type":"address"}],"name":"Withdrawal","type":"event"}]);
+// MetaCoin is our usable abstraction, which we'll use through the code below.
+var SimpleWallet = contract(simpleWallet_artifacts);
+// Bootstrap the MetaCoin abstraction for Use.
+SimpleWallet.setProvider(web3.currentProvider);
 
-// use a simple wallet alread deployed to a specific address
-var simplewallet = simplewalletContract.at("0x02db1f86500cc71d86cf648f87e3f9ef0bf97a7c");
+// var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+//
+// var simplewalletContract = web3.eth.contract([{"constant":true,"inputs":[{"name":"_address","type":"address"}],"name":"isAllowedToSend","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"amount","type":"uint256"},{"name":"receiver","type":"address"}],"name":"sendFunds","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function"},{"constant":false,"inputs":[],"name":"killWallet","outputs":[],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"_address","type":"address"}],"name":"allowAddressToSendMoney","outputs":[],"payable":false,"type":"function"},{"constant":false,"inputs":[{"name":"_address","type":"address"}],"name":"disallowAddressToSendMoney","outputs":[],"payable":false,"type":"function"},{"inputs":[],"payable":false,"type":"constructor"},{"payable":true,"type":"fallback"},{"anonymous":false,"inputs":[{"indexed":false,"name":"_sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"_sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"_beneficiary","type":"address"}],"name":"Withdrawal","type":"event"}]);
+//
+// // use a simple wallet alread deployed to a specific address
+// var simplewallet = simplewalletContract.at("0x02db1f86500cc71d86cf648f87e3f9ef0bf97a7c");
 
 // create a new insance of a wallet
 // var simplewallet = simplewalletContract.new(
@@ -52,13 +62,27 @@ var SimpleWalletView = React.createClass({
   },
   handleAddressSelect: function(value) {
     //var wallet = SimpleWallet.deployed();
-    let ether = web3.fromWei(web3.eth.getBalance(value), 'ether');
-    let allowed = simplewallet.isAllowedToSend.call(value);
+    let ether = this.props.web3.fromWei(this.props.web3.eth.getBalance(value), 'ether');
+    let allowed = true; // simplewallet.isAllowedToSend.call(value);
     this.setState({from: value, balance: ether, allowed: allowed});
   },
   handleSend: function() {
     console.log('sending ' + this.state.amount + ' from ' + this.state.from);
 
+    var wallet;
+    var amount = this.state.amount;
+    var toAddress = this.state.toAddress;
+    var fromAddress = '0xe6e8225f0c328a7e9b9a869bebb1262f25dc65cc';
+
+    SimpleWallet.deployed().then(function(instance) {
+      wallet = instance;
+      // return meta.sendCoin(this.state.toAddress, this.state.amount, {from: account});
+      return wallet.sendFunds(toAddress, amount, {from: fromAddress});
+    }).then(function() {
+      console.log('Transaction successful!');
+    }).catch(function(e) {
+      console.log(e);
+    });
   },
   render: function() {
     return (

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,24 @@
 import React from 'react';
 import ReactDOM  from 'react-dom';
 import Routes from './components/Routes.jsx';
+import Web3 from 'web3';
 
-ReactDOM.render(<Routes /> , document.getElementById('root'));
+//import truffleConfig from '../truffle.js';
+
+//var web3Location = `http://${truffleConfig.rpc.host}:${truffleConfig.rpc.port}`
+
+var web3Location = 'http://localhost:8545';
+
+window.addEventListener('load', function() {
+  var web3Provided;
+  // Supports Metamask and Mist, and other wallets that provide 'web3'.
+  if (typeof web3 === 'undefined') {
+    // Use the Mist/wallet provider.
+    // eslint-disable-next-line
+    web3Provided = new Web3(web3.currentProvider);
+  } else {
+    web3Provided = new Web3(new Web3.providers.HttpProvider(web3Location))
+  }
+
+  ReactDOM.render(<Routes web3={web3Provided} /> , document.getElementById('root'));
+});

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,12 @@
+// Allows us to use ES6 in our migrations and tests.
+require('babel-register')
+
 module.exports = {
-  rpc: {
-    host: 'localhost',
-    port: 8545
-  },
-  "migrations_directory": "./migrations"
+  networks: {
+    development: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '*' // Match any network id
+    }
+  }
 }


### PR DESCRIPTION
This started out as an exercise to get webpack configured to deploy build/deploy solidity contracts.  At one point this was working with the `truffle-solidity-loader` which allowed for hot loading.  The hot loading of contracts was working but was unable to reference the compiled contracts.  (i.e. deployed() not a function error).

In the end, this release is using Truffle v3.1.1 that was was just released.  It is based on truffle-contract rather than ether-pudding.  `truffle compile` now produces json artifacts rather than javascript code.

The real value of this pull request is that the project is now able to use Truffle compiled Solidity contracts.

